### PR TITLE
Add edit todo mutation and input

### DIFF
--- a/web/src/components/TodoItem/TodoItem.js
+++ b/web/src/components/TodoItem/TodoItem.js
@@ -1,18 +1,57 @@
 import styled from 'styled-components'
 import Check from 'src/components/Check'
+import { useEffect, useRef, useState } from 'react'
 
-const TodoItem = ({ id, body, status, onClickCheck }) => {
+const TodoItem = ({ id, body, status, onClickCheck, onClickSave }) => {
+  const [editTodo, setEditTodo] = useState(false)
+  const [newTodo, setNewTodo] = useState(body)
+  const inputRef = useRef()
+
   const handleCheck = () => {
     const newStatus = status === 'off' ? 'on' : 'off'
     onClickCheck(id, newStatus)
   }
+
+  const handleSave = () => {
+    onClickSave(id, newTodo)
+    setEditTodo(false)
+  }
+
+  useEffect(() => {
+    if (editTodo) {
+      inputRef.current.focus()
+    }
+  }, [editTodo])
+
+  const Todo = () => (
+    <>
+      {status === 'on' ? <s>{body}</s> : body}
+      <SC.Button type="submit" value="Edit" onClick={() => setEditTodo(true)} />
+    </>
+  )
 
   return (
     <SC.Item>
       <SC.Target onClick={handleCheck}>
         <Check type={status} />
       </SC.Target>
-      <SC.Body>{status === 'on' ? <s>{body}</s> : body}</SC.Body>
+      <SC.Body>
+        {!editTodo ? (
+          <Todo />
+        ) : (
+          <>
+            <SC.Input
+              type="text"
+              ref={inputRef}
+              value={newTodo}
+              onChange={(e) => {
+                setNewTodo(e.target.value)
+              }}
+            />
+            <SC.Button type="submit" value="Save Item" onClick={handleSave} />
+          </>
+        )}
+      </SC.Body>
     </SC.Item>
   )
 }
@@ -32,6 +71,34 @@ SC.Body = styled.div`
   border-top: 1px solid #efefef;
   padding: 10px 0;
   width: 100%;
+`
+
+SC.Input = styled.input`
+  border: none;
+  font-size: 18px;
+  font-family: 'Inconsolata', monospace;
+  padding: 10px 0;
+  width: 75%;
+
+  ::placeholder {
+    color: #e1e1e1;
+  }
+`
+SC.Button = styled.input`
+  float: right;
+  margin-top: 5px;
+  border-radius: 6px;
+  background-color: #8000ff;
+  padding: 5px 15px;
+  color: white;
+  border: 0;
+  font-size: 18px;
+  font-family: 'Inconsolata', monospace;
+
+  :hover {
+    background-color: black;
+    cursor: pointer;
+  }
 `
 
 export default TodoItem

--- a/web/src/components/TodoListCell/TodoListCell.js
+++ b/web/src/components/TodoListCell/TodoListCell.js
@@ -21,6 +21,16 @@ const UPDATE_TODO_STATUS = gql`
   }
 `
 
+const UPDATE_TODO_BODY = gql`
+  mutation TodoListCell_RenameTodo($id: Int!, $body: String!) {
+    renameTodo(id: $id, body: $body) {
+      id
+      __typename
+      body
+    }
+  }
+`
+
 export const Loading = () => <div>Loading...</div>
 
 export const Empty = () => <div></div>
@@ -29,19 +39,35 @@ export const Failure = () => <div>Oh no</div>
 
 export const Success = ({ todos }) => {
   const [updateTodoStatus] = useMutation(UPDATE_TODO_STATUS)
+  const [updateTodoBody] = useMutation(UPDATE_TODO_BODY)
 
   const handleCheckClick = (id, status) => {
     updateTodoStatus({
       variables: { id, status },
       optimisticResponse: {
         __typename: 'Mutation',
-        updateTodoStatus: { __typename: 'Todo', id, status: 'loading' },
+        updateTodoBody: { __typename: 'Todo', id, status: 'loading' },
+      },
+    })
+  }
+
+  const handleSaveClick = (id, body) => {
+    updateTodoBody({
+      variables: { id, body },
+      optimisticResponse: {
+        __typename: 'Mutation',
+        updateTodoBody: { __typename: 'Todo', id, status: 'loading' },
       },
     })
   }
 
   const list = todos.map((todo) => (
-    <TodoItem key={todo.id} {...todo} onClickCheck={handleCheckClick} />
+    <TodoItem
+      key={todo.id}
+      {...todo}
+      onClickCheck={handleCheckClick}
+      onClickSave={handleSaveClick}
+    />
   ))
 
   return <SC.List>{list}</SC.List>


### PR DESCRIPTION
The problem this PR intends to solve is that the todos should be able to be edited after they have been created.

To solve this, this PR uses the `renameTodo` mutation created in the SDL in the TodoListCell to update the Todo body with the following:

```
const UPDATE_TODO_BODY = gql`
  mutation TodoListCell_RenameTodo($id: Int!, $body: String!) {
    renameTodo(id: $id, body: $body) {
      id
      __typename
      body
    }
  }
`
```

It also performs an optimistic update with the following handler:

```
  const handleSaveClick = (id, body) => {
    updateTodoBody({
      variables: { id, body },
      optimisticResponse: {
        __typename: 'Mutation',
        updateTodoBody: { __typename: 'Todo', id, status: 'loading' },
      },
    })
  }
```

To execute the mutation the PR adds an input field that can be toggled on in the TodoItem

```
const TodoItem = ({ id, body, status, onClickCheck, onClickSave }) => {

  const [editTodo, setEditTodo] = useState(false)
  const [newTodo, setNewTodo] = useState(body)
  const inputRef = useRef()

  const handleSave = () => {
    onClickSave(id, newTodo)
    setEditTodo(false)
  }

  useEffect(() => {
    if (editTodo) {
      inputRef.current.focus()
    }
  }, [editTodo])

// Omited

  return (
      <SC.Item>
        <SC.Target onClick={handleCheck}>
          <Check type={status} />
        </SC.Target>
        <SC.Body>
          {!editTodo ? (
            <Todo />
          ) : (
            <>
              <SC.Input
                type="text"
                ref={inputRef}
                value={newTodo}
                onChange={(e) => {
                  setNewTodo(e.target.value)
                }}
              />
              <SC.Button type="submit" value="Save Item" onClick={handleSave} />
            </>
          )}
        </SC.Body>
      </SC.Item>
    )
}
```
